### PR TITLE
Add simple Dockerfile run the app in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:16
+
+WORKDIR /opt/bgpicker
+
+## Install dependencies
+COPY package*.json ./
+RUN npm install
+
+## Copy app sources and build it for production
+COPY public ./public
+COPY src ./src
+RUN yarn build
+
+## Install serve to be used to serve the static site
+RUN npm install -g serve
+
+## Run the app
+EXPOSE 3000
+CMD [ "serve", "-s", "build" ]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Built with React JS and [chakra UI](https://next.chakra-ui.com/)
 - Run
     - `yarn start`
 
+## Run with Docker
+- Build the docker image:
+    - `docker build . -t bgpicker`
+- Start docker container:
+    - `docker run -p 3000:3000 -d bgpicker`
+
 # Future
 - Add vertical layout option for ranking display
 - Add change width option for the ranking table


### PR DESCRIPTION
Adds a simple Dockerfile that allows to create a docker image based off
Node to run the app.

To build the docker image, simply run:

  docker build . -t <your_image_tag>

Then run the app with:

  docker run -p 3000:3000 -d <your_image_tag>